### PR TITLE
Minor improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
 - jruby-19mode
+env: 'JRUBY_OPTS="-Xcli.debug=true --debug"' # for test coverage
 addons:
   code_climate:
     repo_token:

--- a/lib/everyleaf/embulk_helper/tasks/common.rb
+++ b/lib/everyleaf/embulk_helper/tasks/common.rb
@@ -60,7 +60,7 @@ module Everyleaf
         end
 
         def embulk_tags
-          JSON.parse(open("https://api.github.com/repos/embulk/embulk/tags").read)
+          @embulk_tags ||= JSON.parse(open("https://api.github.com/repos/embulk/embulk/tags").read)
         end
 
         def embulk_versions

--- a/lib/everyleaf/embulk_helper/tasks/generator/gemfiles.rb
+++ b/lib/everyleaf/embulk_helper/tasks/generator/gemfiles.rb
@@ -89,7 +89,7 @@ gem "embulk", "<%= version %>"
             target_versions.map do |version|
               major, minor, _ = version.segments
               Gem::Version.new([major, minor].join("."))
-            end.compact.uniq
+            end.uniq
           end
         end
       end

--- a/lib/everyleaf/embulk_helper/tasks/generator/gemfiles.rb
+++ b/lib/everyleaf/embulk_helper/tasks/generator/gemfiles.rb
@@ -55,6 +55,13 @@ gem "embulk", "<%= version %>"
               next if version < min_version
               create_gemfile(version)
             end
+
+            # e.g. embulk-0.6-latest
+            target_minor_versions.each do |version|
+              create_gemfile("~> #{version}", "#{version}-latest")
+            end
+
+            # embulk-latest
             create_gemfile("> #{min_version}", "latest")
           end
 
@@ -71,6 +78,14 @@ gem "embulk", "<%= version %>"
 
           def gemfile_template_path
             root_dir.join(options[:gemfile_template] || DEFAULT_EMBULK_GEMFILE_TEMPLATE)
+          end
+
+          def target_minor_versions
+            embulk_versions.map do |version|
+              next if version < min_version
+              major, minor, _ = version.segments
+              Gem::Version.new([major, minor].join("."))
+            end.compact.uniq
           end
         end
       end

--- a/lib/everyleaf/embulk_helper/tasks/generator/gemfiles.rb
+++ b/lib/everyleaf/embulk_helper/tasks/generator/gemfiles.rb
@@ -51,13 +51,12 @@ gem "embulk", "<%= version %>"
 
             Dir[gemfiles_dir.join("embulk-*")].each{|f| File.unlink(f)}
 
-            embulk_versions.each do |version|
-              next if version < min_version
+            target_versions.each do |version|
               create_gemfile(version)
             end
 
             # e.g. embulk-0.6-latest
-            target_minor_versions.each do |version|
+            target_versions_without_patch.each do |version|
               create_gemfile("~> #{version}", "#{version}-latest")
             end
 
@@ -80,9 +79,14 @@ gem "embulk", "<%= version %>"
             root_dir.join(options[:gemfile_template] || DEFAULT_EMBULK_GEMFILE_TEMPLATE)
           end
 
-          def target_minor_versions
-            embulk_versions.map do |version|
-              next if version < min_version
+          def target_versions
+            embulk_versions.find_all do |version|
+              version >= min_version
+            end
+          end
+
+          def target_versions_without_patch
+            target_versions.map do |version|
               major, minor, _ = version.segments
               Gem::Version.new([major, minor].join("."))
             end.compact.uniq

--- a/lib/everyleaf/embulk_helper/tasks/generator/travis.rb
+++ b/lib/everyleaf/embulk_helper/tasks/generator/travis.rb
@@ -48,6 +48,10 @@ gemfile:
 <% versions.each do |file| -%>
   - gemfiles/<%= file %>
 <% end -%>
+
+matrix:
+  allow_failures:
+    - gemfile: gemfiles/embulk-0.6.22
             YML
           end
 

--- a/test/everyleaf/embulk_helper/tasks/generator/test_gemfiles.rb
+++ b/test/everyleaf/embulk_helper/tasks/generator/test_gemfiles.rb
@@ -49,7 +49,7 @@ gem "embulk", "<%= version %>"
             end
 
             def minor_versions
-              @task.send(:target_minor_versions)
+              @task.send(:target_versions_without_patch)
             end
           end
 

--- a/test/everyleaf/embulk_helper/tasks/generator/test_gemfiles.rb
+++ b/test/everyleaf/embulk_helper/tasks/generator/test_gemfiles.rb
@@ -23,8 +23,8 @@ gem "embulk", "<%= version %>"
               @task.gemfiles
               files = Dir["#{@task.root_dir}/gemfiles/embulk-*"]
 
-              # all versions + latest version
-              assert_equal(embulk_versions.length + 1, files.length)
+              # all versions + minor versions + latest version
+              assert_equal(embulk_versions.length + minor_versions.length + 1, files.length)
             end
 
             def test_0_1_1_with_env
@@ -32,19 +32,24 @@ gem "embulk", "<%= version %>"
               @task.gemfiles
               files = Dir["#{@task.root_dir}/gemfiles/embulk-*"]
 
-              # all versions + latest version - 0.1.1
-              assert_equal(4, files.length)
+              # 0.1.1 + 0.1.2 + 0.1-latest + 0.2.0 + 0.2-latest + latest version
+              assert_equal(6, files.length)
             ensure
               ENV.delete("MIN_VERSION")
             end
 
             def test_0_1_1_with_options
-              opt = options
-              stub(self).options { opt[:min_vesion] = "0.1.1"; opt }
+              stub(@task).options { options.merge(min_version: "0.1.1") }
+
+              @task.gemfiles
               files = Dir["#{@task.root_dir}/gemfiles/embulk-*"]
 
-              # all versions + latest version - 0.1.1
-              assert_equal(4, files.length)
+              # 0.1.1 + 0.1.2 + 0.1-latest + 0.2.0 + 0.2-latest + latest version
+              assert_equal(6, files.length)
+            end
+
+            def minor_versions
+              @task.send(:target_minor_versions)
             end
           end
 
@@ -123,8 +128,7 @@ gem "embulk", "0.1.2"
             @task.gemfiles
             files = Dir["#{@task.root_dir}/gemfiles/embulk-*"]
 
-            # each version + latest version
-            assert_equal(embulk_versions.length + 1, files.length)
+            assert_true(files.length > 0)
           end
 
           private

--- a/test/everyleaf/embulk_helper/tasks/generator/test_gemfiles.rb
+++ b/test/everyleaf/embulk_helper/tasks/generator/test_gemfiles.rb
@@ -128,7 +128,7 @@ gem "embulk", "0.1.2"
             @task.gemfiles
             files = Dir["#{@task.root_dir}/gemfiles/embulk-*"]
 
-            assert_true(files.length > 0)
+            assert_false(files.empty?)
           end
 
           private


### PR DESCRIPTION
- embulk 0.6.22 is in allow_failures at initial travis template 
- generate 0.x-latest gemfile e.g. embulk-0.6-latest
