### PR TITLE
[travis] Modify template to test Embulk 0.7.x matrix

### DIFF
--- a/lib/everyleaf/embulk_helper/tasks/generator/travis.rb
+++ b/lib/everyleaf/embulk_helper/tasks/generator/travis.rb
@@ -39,10 +39,12 @@ module Everyleaf
           def initial_template
             <<-YML
 language: ruby
+
+jdk: oraclejdk8
+
 rvm:
   - jruby-19mode
-jdk:
-  - oraclejdk8
+  - jruby-9.0.0.0
 
 gemfile:
 <% versions.each do |file| -%>
@@ -50,8 +52,17 @@ gemfile:
 <% end -%>
 
 matrix:
+  exclude:
+    - jdk: oraclejdk8 # Ignore all matrix at first, use `include` to allow build
+  include:
+    <% matrix.each do |m| -%>
+<%= m %>
+    <% end %>
+
   allow_failures:
     - gemfile: gemfiles/embulk-0.6.22
+    - gemfile: gemfiles/embulk-0.7.0
+    - gemfile: gemfiles/embulk-0.7.1
     # Ignore failure for *-latest
     <% versions.find_all{|file| file.to_s.match(/-latest/)}.each do |file| -%>
 - gemfile: <%= file %>
@@ -65,7 +76,6 @@ matrix:
 
           def create_travis_yml
             erb = ERB.new(travis_yml_template_path.read, nil, "-")
-            versions = gemfiles.map(&:basename)
             File.open(root_dir.join(".travis.yml"), "w") do |f|
               f.puts erb.result(binding())
             end
@@ -73,6 +83,19 @@ matrix:
 
           def gemfiles
             Pathname.glob(gemfiles_dir.join("embulk-*"))
+          end
+
+          def versions
+            # for trabis.yml.erb
+            gemfiles.map(&:basename)
+          end
+
+          def matrix
+            # for trabis.yml.erb
+            gemfiles.map do |path|
+              rvm = path.to_s.include?("0.6") ? "jruby-19mode" : "jruby-9.0.0.0"
+              %Q|- {rvm: #{rvm}, gemfile: #{path.relative_path_from(root_dir)}}|
+            end
           end
         end
       end


### PR DESCRIPTION
Generate matrix as such:

``` yaml
matrix:
  exclude:
    - jdk: oraclejdk8 # Ignore all matrix at first, use `include` to allow build
  include:
    - {rvm: jruby-19mode, gemfile: gemfiles/embulk-0.6-latest}
    - {rvm: jruby-19mode, gemfile: gemfiles/embulk-0.6.20}
    - {rvm: jruby-19mode, gemfile: gemfiles/embulk-0.6.21}
    - {rvm: jruby-19mode, gemfile: gemfiles/embulk-0.6.22}
    - {rvm: jruby-19mode, gemfile: gemfiles/embulk-0.6.23}
    - {rvm: jruby-19mode, gemfile: gemfiles/embulk-0.6.24}
    - {rvm: jruby-19mode, gemfile: gemfiles/embulk-0.6.25}
    - {rvm: jruby-19mode, gemfile: gemfiles/embulk-0.6.26}
    - {rvm: jruby-9.0.0.0, gemfile: gemfiles/embulk-0.7-latest}
    - {rvm: jruby-9.0.0.0, gemfile: gemfiles/embulk-0.7.0}
    - {rvm: jruby-9.0.0.0, gemfile: gemfiles/embulk-0.7.1}
    - {rvm: jruby-9.0.0.0, gemfile: gemfiles/embulk-0.7.2}
    - {rvm: jruby-9.0.0.0, gemfile: gemfiles/embulk-0.7.3}
    - {rvm: jruby-9.0.0.0, gemfile: gemfiles/embulk-0.7.4}
    - {rvm: jruby-9.0.0.0, gemfile: gemfiles/embulk-latest}

  allow_failures:
    - gemfile: gemfiles/embulk-0.6.22
    - gemfile: gemfiles/embulk-0.7.0
    - gemfile: gemfiles/embulk-0.7.1
    # Ignore failure for *-latest
    - gemfile: embulk-0.6-latest
    - gemfile: embulk-0.7-latest
    - gemfile: embulk-latest
```
